### PR TITLE
chore: adiciona workflow de CI para lint, typecheck e build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Lint, typecheck, build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    env:
+      # Build-time placeholders. The frontend reads these at build time, and
+      # `next build` fails without them. No real secrets: CI never talks to
+      # Supabase or Stripe.
+      NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: placeholder-anon-key
+      NEXT_PUBLIC_SITE_URL: https://remotedevsbr.com
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Non-blocking for now: the repo currently has ~204 pre-existing ESLint
+      # errors (mostly no-explicit-any). Drop continue-on-error once they are
+      # cleared so lint becomes a real gate.
+      - name: Lint
+        run: npm run lint
+        continue-on-error: true
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
     "supabase:deploy:fetch-og": "supabase functions deploy fetch-og"
   },
   "dependencies": {


### PR DESCRIPTION
## O que muda

Não existe CI no repositório, então nada verifica se lint, tipos e build continuam passando antes de um merge. Um PR do Dependabot (#1) já entrou sem nenhum gate.

- **`.github/workflows/ci.yml`** (novo): roda em push para `master` e em todo PR. Node 20 com cache de npm, `concurrency` cancelando execuções superadas e timeout de 15 minutos.
- **`package.json`**: adiciona o script `typecheck` (`tsc --noEmit`), que não existia.

## Decisão que depende de você: lint está não bloqueante

O lint roda com `continue-on-error: true`. A árvore hoje tem cerca de **204 erros de ESLint pré-existentes** (148 `no-explicit-any`, 27 `react-hooks/set-state-in-effect`, 8 `react/no-unescaped-entities` e alguns outros), então um gate bloqueante de lint nasceria vermelho já na primeira execução e logo seria ignorado.

**Typecheck e build são gates duros** e os dois passam no `master` hoje. O workflow tem um comentário dizendo que o `continue-on-error` deve sair assim que os erros existentes forem resolvidos. Se preferir o contrário, posso deixar o lint bloqueante e resolver os 204 antes.

## Variáveis de ambiente

Os valores `NEXT_PUBLIC_*` no workflow são placeholders de build, porque o `next build` falha sem eles. Não são segredos, e o CI nunca fala com o Supabase nem com a Stripe.

## Verificação

Rodado localmente contra a árvore atual: `tsc --noEmit` limpo e `next build` passando (49 rotas).
