### PR TITLE
feat: migrate AI tools to OpenAI-compatible endpoint (OpenRouter)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,7 @@ NEXT_PUBLIC_SITE_URL=https://your-domain.example
 # Do NOT fill them in here. Set them on your Supabase project with:
 #
 #   supabase secrets set STRIPE_SECRET_KEY=... STRIPE_WEBHOOK_SECRET=...
-#                       LOVABLE_API_KEY=... TELEGRAM_BOT_TOKEN=...
+#                       OPENAI_API_KEY=... TELEGRAM_BOT_TOKEN=...
 #                       TELEGRAM_CHAT_ID=... SITE_URL=https://yourdomain.com
 #
 # or from the project Dashboard > Settings > Secrets (Edge Functions).
@@ -34,8 +34,11 @@ NEXT_PUBLIC_SITE_URL=https://your-domain.example
 # STRIPE_SECRET_KEY=
 # STRIPE_WEBHOOK_SECRET=
 
-# Lovable AI Gateway (LLM inference: analyze-resume, cover-letter, ai-tools)
-# LOVABLE_API_KEY=
+# OpenAI-compatible LLM API (LLM inference: analyze-resume, cover-letter, ai-tools).
+# Default endpoint is OpenRouter (https://openrouter.ai/api/v1); point it elsewhere
+# (e.g. https://api.openai.com/v1) by setting OPENAI_BASE_URL too.
+# OPENAI_API_KEY=
+# OPENAI_BASE_URL=https://openrouter.ai/api/v1
 
 # Telegram notifications (send-notification)
 # TELEGRAM_BOT_TOKEN=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,9 +15,9 @@ The core growth engine for the platform. Developers upload a PDF, we extract the
 
 **Location:** `supabase/functions/analyze-resume/`
 
-**Provider:** Lovable AI Gateway (`https://ai.gateway.lovable.dev`)
+**Provider:** OpenAI-compatible chat completions endpoint via `_shared/ai.ts` (defaults to OpenRouter at `https://openrouter.ai/api/v1`). Configured with the `OPENAI_API_KEY` and optional `OPENAI_BASE_URL` edge secrets.
 
-**Model Choice (current):** Google Gemini Flash via gateway (currently configured as `google/gemini-2.5-flash` in code).
+**Model Choice (current):** Google Gemini Flash via OpenRouter. `google/gemini-2.5-flash` for analyze-resume and cover-letter; `google/gemini-3-flash-preview` for ai-tools.
 * **Why Flash?** Speed and cost-efficiency. Resume analysis requires reading ~1,000-2,000 tokens of raw text and generating a few hundred tokens of structured JSON.
 
 **Token Flow:**
@@ -36,7 +36,7 @@ We use a zero-shot prompt with strict JSON schema enforcement to ensure the outp
 
 Because the Resume Analyzer is a **Free Tool** used to drive top-of-funnel acquisition, managing token costs is paramount.
 
-* **Cost Optimization:** We use a Flash-tier model via the Lovable AI Gateway to keep latency and per-request costs low. Avoid hardcoding cost-per-resume assumptions in product logic; treat pricing as a deploy-time/config concern that can change with provider/model.
+* **Cost Optimization:** We use a Flash-tier model via OpenRouter to keep latency and per-request costs low. Avoid hardcoding cost-per-resume assumptions in product logic; treat pricing as a deploy-time/config concern that can change with provider/model.
 * **Gate Strategy:** While the compute is free, the *value* of the full report is high. We present the user with the partial analysis (`overall_score` + `top_strengths`), but require them to create an account and complete their profile to unlock the `detailed_feedback`. This converts cheap LLM tokens into high-value structured profile data.
 
 ## 3. Future Agent: Recruiter Matchmaker (Phase 6)
@@ -58,7 +58,7 @@ The upcoming Phase 6 of the strategic sequence involves building an AI-driven ma
 
 ## 4. Edge Function Security & Best Practices
 
-* **No direct client-to-LLM calls:** All AI requests route through Supabase Edge Functions. The `GEMINI_API_KEY` is securely stored in Supabase Vault/Secrets and is never exposed to the frontend.
+* **No direct client-to-LLM calls:** All AI requests route through Supabase Edge Functions. The `OPENAI_API_KEY` is securely stored in Supabase Vault/Secrets and is never exposed to the frontend.
 * **Rate Limiting:** We currently rate-limit resume uploads per anonymous session to prevent abuse of the API key.
 * **JSON Validation:** LLM responses are parsed and sanitized before being inserted into the `resume_analyses` table to prevent injection or schema-breaking errors on the frontend.
 
@@ -86,8 +86,8 @@ This serves as a quick-reference map for all major touchpoints within the archit
 * `/recruiter/pricing` - Stripe checkout for Professional/Enterprise tiers.
 
 ### Supabase Edge Functions (API)
-* `analyze-resume` (POST) - Takes a PDF or text, extracts text if needed, calls the Lovable AI Gateway (Gemini Flash), stores `resume_analyses`, and returns partial + gated full report.
-* `ai-tools` (POST) - Resume builder + LinkedIn tuner via Lovable AI Gateway (currently configured as `google/gemini-3-flash-preview`).
+* `analyze-resume` (POST) - Takes a PDF or text, extracts text if needed, calls the shared OpenAI-compatible helper (Gemini Flash via OpenRouter), stores `resume_analyses`, and returns partial + gated full report.
+* `ai-tools` (POST) - Resume builder + LinkedIn tuner via OpenRouter through the shared OpenAI-compatible helper (currently configured as `google/gemini-3-flash-preview`).
 * `track-activity` (POST) - Logs user actions, updates daily streaks, and checks for newly unlocked achievements.
 * `process-engagement-emails` (CRON) - Background job that emails users about lost streaks or incomplete profiles.
 * `recruiter-search` (POST) - Queries the `profiles` table. Returns full or obfuscated (blurred) data depending on the recruiter's subscription tier.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ supabase functions deploy cover-letter
 Set function secrets (required for AI and payments):
 
 ```bash
-supabase secrets set LOVABLE_API_KEY=... STRIPE_SECRET_KEY=... TELEGRAM_BOT_TOKEN=...
+supabase secrets set OPENAI_API_KEY=... STRIPE_SECRET_KEY=... TELEGRAM_BOT_TOKEN=...
 ```
 
 Hosted Supabase injects `SUPABASE_URL`, `SUPABASE_ANON_KEY`, and `SUPABASE_SERVICE_ROLE_KEY` at runtime; for local runs the CLI provides them too. CRON functions (e.g. `process-engagement-emails`) are scheduled from the Supabase dashboard.
@@ -109,7 +109,8 @@ Hosted Supabase injects `SUPABASE_URL`, `SUPABASE_ANON_KEY`, and `SUPABASE_SERVI
 | `SUPABASE_URL` | all functions | Yes, injected by Supabase |
 | `SUPABASE_ANON_KEY` | authenticated functions | Yes, injected by Supabase |
 | `SUPABASE_SERVICE_ROLE_KEY` | server-side data access | Yes, injected by Supabase |
-| `LOVABLE_API_KEY` | `analyze-resume`, `cover-letter`, `ai-tools` | For AI tools |
+| `OPENAI_API_KEY` | `analyze-resume`, `cover-letter`, `ai-tools` | For AI tools |
+| `OPENAI_BASE_URL` | `analyze-resume`, `cover-letter`, `ai-tools` | Optional, defaults to `https://openrouter.ai/api/v1` |
 | `STRIPE_SECRET_KEY` | `stripe-*` functions, `check-subscription` | For payments |
 | `STRIPE_WEBHOOK_SECRET` | `stripe-webhook` | For payments |
 | `TELEGRAM_BOT_TOKEN` | `send-notification` | For notifications |

--- a/supabase/functions/_shared/ai.ts
+++ b/supabase/functions/_shared/ai.ts
@@ -1,0 +1,66 @@
+// Shared OpenAI-compatible chat completions client for the free AI tools.
+// Provider-agnostic: any compatible endpoint works. Set OPENAI_API_KEY and,
+// optionally, OPENAI_BASE_URL (defaults to OpenRouter).
+export interface CallAIOptions {
+  model: string;
+  json?: boolean;
+}
+
+export type CallAIResult =
+  | { ok: true; text: string }
+  | { ok: false; error: string; status: number };
+
+const DEFAULT_BASE_URL = "https://openrouter.ai/api/v1";
+const APP_TITLE = "RemoteDevsBR";
+const REQUEST_TIMEOUT_MS = 60_000;
+
+export async function callAI(
+  system: string,
+  user: string,
+  opts: CallAIOptions
+): Promise<CallAIResult> {
+  const apiKey = Deno.env.get("OPENAI_API_KEY");
+  if (!apiKey) throw new Error("OPENAI_API_KEY is not configured");
+
+  const baseUrl = (Deno.env.get("OPENAI_BASE_URL") ?? DEFAULT_BASE_URL).trim().replace(/\/+$/, "");
+  const siteUrl = Deno.env.get("SITE_URL")?.trim().replace(/\/+$/, "");
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${apiKey}`,
+    "Content-Type": "application/json",
+  };
+  if (siteUrl) headers["HTTP-Referer"] = siteUrl;
+  headers["X-Title"] = APP_TITLE;
+
+  const body: Record<string, unknown> = {
+    model: opts.model,
+    messages: [
+      { role: "system", content: system },
+      { role: "user", content: user },
+    ],
+  };
+  if (opts.json) body.response_format = { type: "json_object" };
+
+  const resp = await fetch(`${baseUrl}/chat/completions`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+
+  if (resp.status === 429) {
+    return { ok: false, error: "Rate limit reached, try again in a moment.", status: 429 };
+  }
+  if (resp.status === 402) {
+    return { ok: false, error: "AI credits exhausted, add credits to continue.", status: 402 };
+  }
+  if (!resp.ok) {
+    const detail = await resp.text();
+    console.error("chat completions error", resp.status, detail);
+    return { ok: false, error: "AI request failed", status: 500 };
+  }
+
+  const data = await resp.json();
+  const text = data?.choices?.[0]?.message?.content ?? "";
+  return { ok: true, text };
+}

--- a/supabase/functions/ai-tools/index.ts
+++ b/supabase/functions/ai-tools/index.ts
@@ -1,13 +1,11 @@
-// AI tools edge function - resume builder + LinkedIn tuner via Lovable AI Gateway.
+// AI tools edge function - resume builder + LinkedIn tuner.
 import { corsHeaders } from "https://esm.sh/@supabase/supabase-js@2.95.0/cors";
+import { callAI } from "../_shared/ai.ts";
 
 Deno.serve(async (req) => {
   if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
 
   try {
-    const LOVABLE_API_KEY = Deno.env.get("LOVABLE_API_KEY");
-    if (!LOVABLE_API_KEY) throw new Error("LOVABLE_API_KEY is not configured");
-
     const { kind, payload } = await req.json();
     if (!["resume", "linkedin"].includes(kind)) {
       return new Response(JSON.stringify({ error: "Invalid kind" }), { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } });
@@ -34,36 +32,12 @@ Current about:
 ${payload.about || ""}`;
     }
 
-    const resp = await fetch("https://ai.gateway.lovable.dev/v1/chat/completions", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${LOVABLE_API_KEY}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        model: "google/gemini-3-flash-preview",
-        messages: [
-          { role: "system", content: system },
-          { role: "user", content: user },
-        ],
-      }),
-    });
-
-    if (resp.status === 429) {
-      return new Response(JSON.stringify({ error: "Rate limit reached, try again in a moment." }), { status: 429, headers: { ...corsHeaders, "Content-Type": "application/json" } });
-    }
-    if (resp.status === 402) {
-      return new Response(JSON.stringify({ error: "AI credits exhausted. Add credits in Lovable workspace." }), { status: 402, headers: { ...corsHeaders, "Content-Type": "application/json" } });
-    }
-    if (!resp.ok) {
-      const t = await resp.text();
-      console.error("AI gateway error", resp.status, t);
-      return new Response(JSON.stringify({ error: "AI gateway error" }), { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } });
+    const ai = await callAI(system, user, { model: "google/gemini-3-flash-preview" });
+    if (!ai.ok) {
+      return new Response(JSON.stringify({ error: ai.error }), { status: ai.status, headers: { ...corsHeaders, "Content-Type": "application/json" } });
     }
 
-    const data = await resp.json();
-    const text = data?.choices?.[0]?.message?.content ?? "";
-    return new Response(JSON.stringify({ text }), { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } });
+    return new Response(JSON.stringify({ text: ai.text }), { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } });
   } catch (e) {
     console.error("ai-tools error:", e);
     return new Response(JSON.stringify({ error: e instanceof Error ? e.message : "Unknown error" }), { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } });

--- a/supabase/functions/analyze-resume/index.ts
+++ b/supabase/functions/analyze-resume/index.ts
@@ -3,6 +3,7 @@
 // JWT-based identity binding when a session is present, and input/email validation.
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.95.0";
 import { enforceRateLimit } from "../_shared/rate_limit.ts";
+import { callAI } from "../_shared/ai.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -13,7 +14,6 @@ const corsHeaders = {
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY") ?? "";
 const SERVICE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
-const LOVABLE_API_KEY = Deno.env.get("LOVABLE_API_KEY")!;
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -29,27 +29,6 @@ async function extractPdfText(bytes: Uint8Array): Promise<string> {
     console.error("pdf-parse failed", e);
     return "";
   }
-}
-
-async function callAI(system: string, user: string, json = true) {
-  const resp = await fetch("https://ai.gateway.lovable.dev/v1/chat/completions", {
-    method: "POST",
-    headers: { Authorization: `Bearer ${LOVABLE_API_KEY}`, "Content-Type": "application/json" },
-    body: JSON.stringify({
-      model: "google/gemini-2.5-flash",
-      messages: [
-        { role: "system", content: system },
-        { role: "user", content: user },
-      ],
-      ...(json ? { response_format: { type: "json_object" } } : {}),
-    }),
-  });
-  if (!resp.ok) {
-    const t = await resp.text();
-    throw new Error(`AI ${resp.status}: ${t}`);
-  }
-  const data = await resp.json();
-  return data?.choices?.[0]?.message?.content ?? "";
 }
 
 // Returns the authenticated user's id from the request JWT, or null for anonymous callers.
@@ -104,7 +83,7 @@ Deno.serve(async (req) => {
         ? `Target role for this evaluation: ${roleHint}\n\n--- RESUME ---\n${text}`
         : text;
 
-      const partialJson = await callAI(
+      const ai = await callAI(
         `You are a senior tech recruiter evaluating Brazilian developers for US remote roles (ATS + human review). Return STRICT JSON with:
 - overall_score (0-100 integer)
 - english_signal ("low"|"medium"|"high")
@@ -117,9 +96,11 @@ Deno.serve(async (req) => {
 - quick_win (one sentence: highest-impact fix)
 Be candid but constructive.${roleHint ? " Weight role_fit against the target role provided." : " If no target role, score role_fit based on general US remote tech market fit."}`,
         userPayload,
+        { model: "google/gemini-2.5-flash", json: true },
       );
+      if (!ai.ok) return json({ error: ai.error }, ai.status);
       let partial: any = {};
-      try { partial = JSON.parse(partialJson); } catch { partial = { raw: partialJson }; }
+      try { partial = JSON.parse(ai.text); } catch { partial = { raw: ai.text }; }
 
       if (roleHint) partial.target_role = roleHint;
 
@@ -152,7 +133,7 @@ Be candid but constructive.${roleHint ? " Weight role_fit against the target rol
         const fullPayload = partialRole
           ? `Target role: ${partialRole}\n\n--- RESUME ---\n${row.resume_text ?? ""}`
           : (row.resume_text ?? "");
-        const fullJson = await callAI(
+        const ai = await callAI(
           `You are a senior tech recruiter and career coach for Brazilian devs targeting US remote roles. Produce STRICT JSON with:
 - ats_score (0-100)
 - readiness_summary (2-3 sentences)
@@ -165,8 +146,10 @@ Be candid but constructive.${roleHint ? " Weight role_fit against the target rol
 - role_fit_summary (2 sentences on fit for target role, or general US remote fit if none)
 - category_scores (same 6 ids as partial: ats, keywords, formatting, impact, english, role_fit - refine scores with tips)`,
           fullPayload,
+          { model: "google/gemini-2.5-flash", json: true },
         );
-        try { full = JSON.parse(fullJson); } catch { full = { raw: fullJson }; }
+        if (!ai.ok) return json({ error: ai.error }, ai.status);
+        try { full = JSON.parse(ai.text); } catch { full = { raw: ai.text }; }
       }
 
       await supabase.from("resume_analyses").update({

--- a/supabase/functions/cover-letter/index.ts
+++ b/supabase/functions/cover-letter/index.ts
@@ -3,6 +3,7 @@
 // rate limiting, JWT-based identity binding when a session is present, and validation.
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.95.0";
 import { enforceRateLimit } from "../_shared/rate_limit.ts";
+import { callAI as callOpenAIRoute } from "../_shared/ai.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -13,7 +14,6 @@ const corsHeaders = {
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY") ?? "";
 const SERVICE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
-const LOVABLE_API_KEY = Deno.env.get("LOVABLE_API_KEY")!;
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -63,32 +63,12 @@ function json(data: unknown, status: number) {
   });
 }
 
-async function callAI(system: string, user: string) {
-  const resp = await fetch("https://ai.gateway.lovable.dev/v1/chat/completions", {
-    method: "POST",
-    headers: { Authorization: `Bearer ${LOVABLE_API_KEY}`, "Content-Type": "application/json" },
-    body: JSON.stringify({
-      model: "google/gemini-2.5-flash",
-      messages: [
-        { role: "system", content: system },
-        { role: "user", content: user },
-      ],
-      response_format: { type: "json_object" },
-    }),
-  });
-  if (resp.status === 429) {
-    return { error: "Rate limit reached, try again in a moment.", status: 429 };
+async function runAI(system: string, user: string) {
+  const ai = await callOpenAIRoute(system, user, { model: "google/gemini-2.5-flash", json: true });
+  if (!ai.ok) {
+    return { error: ai.error, status: ai.status };
   }
-  if (resp.status === 402) {
-    return { error: "AI credits exhausted.", status: 402 };
-  }
-  if (!resp.ok) {
-    const t = await resp.text();
-    console.error("AI error", resp.status, t);
-    return { error: "AI gateway error", status: 500 };
-  }
-  const data = await resp.json();
-  const raw = data?.choices?.[0]?.message?.content ?? "{}";
+  const raw = ai.text ?? "{}";
   try {
     return { data: JSON.parse(raw) };
   } catch {
@@ -100,7 +80,6 @@ Deno.serve(async (req) => {
   if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
 
   try {
-    if (!LOVABLE_API_KEY) throw new Error("LOVABLE_API_KEY is not configured");
     const supabase = createClient(SUPABASE_URL, SERVICE_KEY);
     const body = await req.json();
     const { action } = body;
@@ -166,7 +145,7 @@ ${jd.slice(0, 8000)}
 --- CANDIDATE RESUME / EXPERIENCE ---
 ${resume.slice(0, 12000)}`;
 
-      const ai = await callAI(system, user);
+      const ai = await runAI(system, user);
       if (ai.error) {
         return json({ error: ai.error }, ai.status ?? 500);
       }
@@ -277,7 +256,7 @@ ${jd.slice(0, 8000)}
 --- COVER LETTER TO REVIEW ---
 ${letterText.slice(0, 6000)}`;
 
-      const ai = await callAI(system, userPrompt);
+      const ai = await runAI(system, userPrompt);
       if (ai.error) {
         return json({ error: ai.error }, ai.status ?? 500);
       }


### PR DESCRIPTION
## Summary

Migrates the free AI tools (`analyze-resume`, `cover-letter`, `ai-tools`) from the Lovable AI Gateway to an OpenAI-compatible Chat Completions endpoint, defaulting to OpenRouter.

The code now speaks the OpenAI API contract, so pointing at any compatible provider is a config change, not a code change.

## Changes

- **New shared client** `supabase/functions/_shared/ai.ts`
  - `callAI(system, user, { model, json })` against `POST {base}/chat/completions`
  - Reads `OPENAI_API_KEY`, optional `OPENAI_BASE_URL` (defaults to `https://openrouter.ai/api/v1`)
  - OpenRouter attribution headers (`HTTP-Referer`, `X-Title`) sent when `SITE_URL` is set; ignored by other providers
  - 60s request timeout
  - Client-safe error mapping for 429 / 402 / other failures (upstream body is logged server-side only)
- **Refactored** the 3 edge functions to use the shared client. Models are unchanged:
  - `analyze-resume`, `cover-letter`: `google/gemini-2.5-flash`
  - `ai-tools`: `google/gemini-3-flash-preview`
- **Docs/env**: `.env.example`, `README.md`, `AGENTS.md` updated: `LOVABLE_API_KEY` removed, `OPENAI_API_KEY` and `OPENAI_BASE_URL` added.

## Behavior notes

- Client-visible responses are unchanged, except: `analyze-resume` now returns real 429/402 statuses instead of a generic 500, and the 402 message no longer references Lovable.
- API keys ship as empty env references in `.env.example`; no secrets are committed.

## Deploy / config (after merge)

```bash
supabase functions deploy analyze-resume cover-letter ai-tools
supabase secrets set OPENAI_API_KEY=<key> --project-ref <ref>
# optional, to leave OpenRouter default:
# supabase secrets unset LOVABLE_API_KEY --project-ref <ref>
```

## Verification

- `deno check` passes for all 4 edge-function files (shared module + 3 functions).
- ESLint on the changed files introduces no new issues (3 pre-existing `any`/`@ts-ignore` in `analyze-resume` remain).