### PR TITLE
fix: return 400 on invalid JSON body in AI functions

### DIFF
--- a/supabase/functions/ai-tools/index.ts
+++ b/supabase/functions/ai-tools/index.ts
@@ -6,7 +6,11 @@ Deno.serve(async (req) => {
   if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
 
   try {
-    const { kind, payload } = await req.json();
+    const body = await req.json().catch(() => null);
+    if (!body || typeof body !== "object") {
+      return new Response(JSON.stringify({ error: "Invalid JSON body" }), { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } });
+    }
+    const { kind, payload } = body;
     if (!["resume", "linkedin"].includes(kind)) {
       return new Response(JSON.stringify({ error: "Invalid kind" }), { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } });
     }

--- a/supabase/functions/analyze-resume/index.ts
+++ b/supabase/functions/analyze-resume/index.ts
@@ -55,7 +55,10 @@ Deno.serve(async (req) => {
   if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
   try {
     const supabase = createClient(SUPABASE_URL, SERVICE_KEY);
-    const body = await req.json();
+    const body = await req.json().catch(() => null);
+    if (!body || typeof body !== "object") {
+      return json({ error: "Invalid JSON body" }, 400);
+    }
     const { action } = body;
 
     // ---------- ACTION: analyze (creates a partial analysis) ----------

--- a/supabase/functions/cover-letter/index.ts
+++ b/supabase/functions/cover-letter/index.ts
@@ -81,7 +81,10 @@ Deno.serve(async (req) => {
 
   try {
     const supabase = createClient(SUPABASE_URL, SERVICE_KEY);
-    const body = await req.json();
+    const body = await req.json().catch(() => null);
+    if (!body || typeof body !== "object") {
+      return json({ error: "Invalid JSON body" }, 400);
+    }
     const { action } = body;
 
     if (action === "generate") {


### PR DESCRIPTION
## Summary

Fixes a 500 on the AI edge functions when a request arrives with an empty or non-JSON body.

`req.json()` throws `SyntaxError: Unexpected end of JSON input` on an empty body, which the outer `catch` turned into a 500. Now the functions parse defensively and answer `400 {"error":"Invalid JSON body"}`.

## Changes

- `supabase/functions/analyze-resume/index.ts`
- `supabase/functions/cover-letter/index.ts`
- `supabase/functions/ai-tools/index.ts`

Each parses the body with `await req.json().catch(() => null)` and rejects non-object bodies with a 400 before destructuring `action` / `kind`.

## Verification

- `deno check` passes for all 3 functions.