### PR TITLE
docs: document CI/CD secrets in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,3 +46,18 @@ NEXT_PUBLIC_SITE_URL=https://your-domain.example
 
 # Public app URL used in payment redirects (stripe-recruiter-checkout)
 # SITE_URL=
+
+# -----------------------------------------------------------------------------
+# CI/CD (GitHub Actions) secrets: documentation only.
+#
+# The deploy job in .github/workflows/ci.yml reads these from GitHub Actions
+# secrets, NOT from this file or Supabase secrets. Add them in the repo at
+# Settings > Secrets and variables > Actions. If they are missing, the deploy
+# job is skipped silently. The value is a project ref, never the anon/service key.
+# -----------------------------------------------------------------------------
+
+# Personal access token from https://supabase.com/dashboard/account/tokens
+# SUPABASE_ACCESS_TOKEN=
+
+# Supabase project reference (e.g. rnk...)
+# SUPABASE_PROJECT_REF=


### PR DESCRIPTION
Documents the two GitHub Actions secrets used by the deploy job (PR #6): SUPABASE_ACCESS_TOKEN and SUPABASE_PROJECT_REF. Documentation-only; no values referenced, repo settings instruct contributors to set these in the GitHub repo under Settings > Secrets, mirroring the existing edge-function secrets section.