### PR TITLE
fix: retry transient AI rate limits and loosen IP limits

### DIFF
--- a/supabase/functions/_shared/ai.ts
+++ b/supabase/functions/_shared/ai.ts
@@ -13,6 +13,7 @@ export type CallAIResult =
 const DEFAULT_BASE_URL = "https://openrouter.ai/api/v1";
 const APP_TITLE = "RemoteDevsBR";
 const REQUEST_TIMEOUT_MS = 60_000;
+const MAX_ATTEMPTS = 3;
 
 export async function callAI(
   system: string,
@@ -41,12 +42,7 @@ export async function callAI(
   };
   if (opts.json) body.response_format = { type: "json_object" };
 
-  const resp = await fetch(`${baseUrl}/chat/completions`, {
-    method: "POST",
-    headers,
-    body: JSON.stringify(body),
-    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-  });
+  const resp = await callWithRetry(body, headers, baseUrl);
 
   if (resp.status === 429) {
     return { ok: false, error: "Rate limit reached, try again in a moment.", status: 429 };
@@ -63,4 +59,25 @@ export async function callAI(
   const data = await resp.json();
   const text = data?.choices?.[0]?.message?.content ?? "";
   return { ok: true, text };
+}
+
+async function callWithRetry(
+  body: Record<string, unknown>,
+  headers: Record<string, string>,
+  baseUrl: string
+): Promise<Response> {
+  let resp: Response | undefined;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    resp = await fetch(`${baseUrl}/chat/completions`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    const transient = resp.status === 429 || resp.status >= 500;
+    if (!transient || attempt === MAX_ATTEMPTS) break;
+    await new Promise((r) => setTimeout(r, 750 * attempt));
+  }
+  if (!resp) throw new Error("AI request failed to start");
+  return resp;
 }

--- a/supabase/functions/analyze-resume/index.ts
+++ b/supabase/functions/analyze-resume/index.ts
@@ -63,7 +63,7 @@ Deno.serve(async (req) => {
 
     // ---------- ACTION: analyze (creates a partial analysis) ----------
     if (action === "analyze") {
-      const rl = await enforceRateLimit(req, "resume-analyze", 3, 60 * 60 * 1000, supabase);
+      const rl = await enforceRateLimit(req, "resume-analyze", 10, 60 * 60 * 1000, supabase);
       if (!rl.allowed) return json({ error: rl.error }, rl.status);
 
       const { file_base64, file_name, resume_text, user_id, target_role } = body;
@@ -120,7 +120,7 @@ Be candid but constructive.${roleHint ? " Weight role_fit against the target rol
 
     // ---------- ACTION: unlock (email gate → full report) ----------
     if (action === "unlock") {
-      const rl = await enforceRateLimit(req, "resume-unlock", 5, 60 * 60 * 1000, supabase);
+      const rl = await enforceRateLimit(req, "resume-unlock", 20, 60 * 60 * 1000, supabase);
       if (!rl.allowed) return json({ error: rl.error }, rl.status);
 
       const { id, email } = body;

--- a/supabase/functions/cover-letter/index.ts
+++ b/supabase/functions/cover-letter/index.ts
@@ -88,7 +88,7 @@ Deno.serve(async (req) => {
     const { action } = body;
 
     if (action === "generate") {
-      const rl = await enforceRateLimit(req, "cover-generate", 5, 60 * 60 * 1000, supabase);
+      const rl = await enforceRateLimit(req, "cover-generate", 10, 60 * 60 * 1000, supabase);
       if (!rl.allowed) return json({ error: rl.error }, rl.status);
 
       const {
@@ -207,7 +207,7 @@ ${resume.slice(0, 12000)}`;
     }
 
     if (action === "unlock") {
-      const rl = await enforceRateLimit(req, "cover-unlock", 5, 60 * 60 * 1000, supabase);
+      const rl = await enforceRateLimit(req, "cover-unlock", 20, 60 * 60 * 1000, supabase);
       if (!rl.allowed) return json({ error: rl.error }, rl.status);
 
       const { id, email } = body;
@@ -223,7 +223,7 @@ ${resume.slice(0, 12000)}`;
     }
 
     if (action === "analyze-letter") {
-      const rl = await enforceRateLimit(req, "cover-analyze-letter", 10, 60 * 60 * 1000, supabase);
+      const rl = await enforceRateLimit(req, "cover-analyze-letter", 20, 60 * 60 * 1000, supabase);
       if (!rl.allowed) return json({ error: rl.error }, rl.status);
 
       const { job_description, target_role, cover_letter, language = "en" } = body;


### PR DESCRIPTION
Improves AI tool usability when OpenRouter's free tier throttles.

Why: the 429 'Rate limit reached, try again in a moment.' comes from OpenRouter's free-tier per-minute limit, not our own limiter. Also our per-IP limits (analyze-resume 3/h, cover-letter 5/h) were tighter than necessary.

Changes:
- _shared/ai.ts: retry up to 3 attempts with short backoff (750ms, 1.5s) for transient 429 and 5xx responses before surfacing the error.
- analyze-resume: resume-analyze 3/h -> 10/h, resume-unlock 5/h -> 20/h.
- cover-letter: cover-generate 5/h -> 10/h, cover-unlock 5/h -> 20/h, cover-analyze-letter 10/h -> 20/h.

Notes:
- OpenRouter's free tier also enforces a per-account daily cap (shared across all IPs); the retry handles per-minute spikes, the daily cap still requires waiting or adding credits.
- ai-tools has no local IP limit and is only bounded by the provider retry.
- deno check passes.