### PR TITLE
fix: respect selected language in invoice print and add browser locale detection

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -5,12 +5,44 @@ import { Toaster as Sonner } from "@/components/ui/sonner";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { I18nProvider, useI18n } from "@/lib/i18n";
-import { AuthProvider } from "@/lib/auth";
+import { AuthProvider, useAuth } from "@/lib/auth";
+import { supabase } from "@/integrations/supabase/client";
 import { AuthModalProvider } from "@/lib/auth-modal";
 import { AuthModal } from "@/components/AuthModal";
 import { ReactNode, useState, useEffect } from "react";
 import { FeatureTogglesProvider, useFeatureToggles } from "@/lib/feature-toggles";
 
+/**
+ * Syncs the app locale with the signed-in user's Supabase profile. On login it
+ * applies the profile's saved locale (overriding cookie/localStorage), and on
+ * locale change it writes the preference back to the profile so it persists
+ * across devices. Sits inside both I18nProvider and AuthProvider.
+ */
+function LocaleSync({ children }: { children: ReactNode }) {
+  const { user, profile } = useAuth();
+  const { locale, setLocale } = useI18n();
+
+  // Apply the profile's saved locale once it loads, overriding toggled value.
+  useEffect(() => {
+    if (!user || !profile) return;
+    if ((profile.locale === "pt" || profile.locale === "en") && profile.locale !== locale) {
+      setLocale(profile.locale);
+    }
+  }, [user, profile, locale, setLocale]);
+
+  // Write the current locale back to the profile once it has loaded (so the
+  // initial read wins), and only when it differs from the persisted value.
+  useEffect(() => {
+    if (!user || !profile) return;
+    if (profile.locale === locale) return;
+    supabase
+      .from("profiles")
+      .upsert({ id: user.id, locale }, { onConflict: "id" })
+      .then(() => {});
+  }, [locale, user, profile]);
+
+  return <>{children}</>;
+}
 /**
  * Forces locale to "pt" when the "is_english_lang_enabled" feature flag is
  * disabled. Sits inside both I18nProvider and FeatureTogglesProvider so it
@@ -36,6 +68,7 @@ export function Providers({ children }: { children: ReactNode }) {
     <QueryClientProvider client={queryClient}>
       <I18nProvider>
         <AuthProvider>
+          <LocaleSync>
           <FeatureTogglesProvider>
             <EnglishLangGuard>
               <AuthModalProvider>
@@ -48,6 +81,7 @@ export function Providers({ children }: { children: ReactNode }) {
               </AuthModalProvider>
             </EnglishLangGuard>
           </FeatureTogglesProvider>
+          </LocaleSync>
         </AuthProvider>
       </I18nProvider>
     </QueryClientProvider>

--- a/app/tools/invoice-generator/page.tsx
+++ b/app/tools/invoice-generator/page.tsx
@@ -190,7 +190,7 @@ export default function InvoiceGeneratorPage() {
         toast.error(t("invoice.printError"));
       }
     } else {
-      toast.success(t("invoice.invoiceNumber") + " #" + newInvoiceNumber + " updated");
+      toast.success(t("invoice.invoiceNumber") + " #" + newInvoiceNumber + " " + t("invoice.updated"));
     }
   };
 

--- a/components/InvoicePreview.tsx
+++ b/components/InvoicePreview.tsx
@@ -37,6 +37,13 @@ interface InvoicePreviewProps {
 
 const mapLocale = (locale: string) => (locale === "pt" ? "pt-BR" : "en-US");
 
+const formatDate = (isoDate: string | undefined, locale: string) => {
+  if (!isoDate) return "";
+  const d = new Date(`${isoDate}T00:00:00`);
+  if (Number.isNaN(d.getTime())) return isoDate;
+  return d.toLocaleDateString(mapLocale(locale), { month: "long", day: "numeric", year: "numeric" });
+};
+
 export const SUPPORTED_INVOICE_CURRENCIES = ["BRL", "USD", "EUR"] as const;
 export type InvoiceCurrency = (typeof SUPPORTED_INVOICE_CURRENCIES)[number];
 
@@ -84,12 +91,12 @@ export function InvoicePreview({ data, t, locale, isPrint = false }: InvoicePrev
   useEffect(() => {
     if (isPrint) {
       const originalTitle = document.title;
-      document.title = `Invoice ${data.invoiceNumber || "1"}`;
+      document.title = `${t("invoice.title")} ${data.invoiceNumber || "1"}`;
       return () => {
         document.title = originalTitle;
       };
     }
-  }, [isPrint, data.invoiceNumber]);
+  }, [isPrint, data.invoiceNumber, t]);
 
   return (
     <div className="bg-white text-black w-full max-w-[900px] mx-auto rounded-xl border border-zinc-200 p-8 shadow-sm invoice-preview-root">
@@ -148,7 +155,7 @@ export function InvoicePreview({ data, t, locale, isPrint = false }: InvoicePrev
             {!shouldHideField(data.date, t("invoice.datePlaceholder"), isPrint) && (
               <div className="grid grid-cols-[1fr_auto] gap-5">
                 <span className="text-zinc-500">{t("invoice.date")}:</span>
-                <span>{getFieldValue(data.date, t("invoice.datePlaceholder"), isPrint)}</span>
+                <span>{formatDate(data.rawDate, locale) || data.date}</span>
               </div>
             )}
             {!shouldHideField(data.paymentTerms, t("invoice.paymentTermsPlaceholder"), isPrint) && (
@@ -160,7 +167,7 @@ export function InvoicePreview({ data, t, locale, isPrint = false }: InvoicePrev
             {!shouldHideField(data.dueDate, t("invoice.datePlaceholder"), isPrint) && (
               <div className="grid grid-cols-[1fr_auto] gap-5">
                 <span className="text-zinc-500">{t("invoice.dueDate")}:</span>
-                <span>{getFieldValue(data.dueDate, t("invoice.datePlaceholder"), isPrint)}</span>
+                <span>{formatDate(data.rawDueDate, locale) || data.dueDate}</span>
               </div>
             )}
             {!shouldHideField(data.poNumber, t("invoice.poNumberPlaceholder"), isPrint) && (

--- a/docs/superpowers/specs/2026-08-31-invoice-i18n-print-and-lang-detection-design.md
+++ b/docs/superpowers/specs/2026-08-31-invoice-i18n-print-and-lang-detection-design.md
@@ -1,0 +1,211 @@
+# Invoice Print i18n Fix & Browser Language Detection
+
+## Problem Statement
+
+1. **Invoice print dates are locale-locked:** The invoice generator formats dates at creation time (e.g., "31 de agosto de 2026") and stores them as static strings. When an English user prints, the date remains in Portuguese because `InvoicePreview` displays `data.date` directly without re-formatting.
+
+2. **No browser language detection:** The i18n system defaults to Portuguese (`"pt"`) for all first-time visitors, regardless of their browser language. Users must manually toggle.
+
+3. **No cookie persistence:** Language preference is stored only in `localStorage`, which is inaccessible to server-side rendering. No cross-device persistence for logged-in users.
+
+4. **Hardcoded English strings in invoice:** `document.title` in the print view and a toast message contain hardcoded English text.
+
+---
+
+## Design
+
+### 1. Invoice Date Formatting Fix
+
+**File:** `components/InvoicePreview.tsx`
+
+**Change:** Format dates dynamically from `rawDate`/`rawDueDate` using `Intl.DateTimeFormat` instead of displaying the pre-formatted `date`/`dueDate` strings.
+
+```typescript
+const formatDate = (isoDate: string | undefined, locale: string) => {
+  if (!isoDate) return "";
+  const d = new Date(`${isoDate}T00:00:00`);
+  if (Number.isNaN(d.getTime())) return isoDate;
+  return d.toLocaleDateString(mapLocale(locale), { month: "long", day: "numeric", year: "numeric" });
+};
+```
+
+**Usage in component:**
+- Line 151: `{formatDate(data.rawDate, locale) || data.date}` (fallback to `data.date` for legacy data without `rawDate`)
+- Line 163: `{formatDate(data.rawDueDate, locale) || data.dueDate}` (same fallback)
+
+**Fallback strategy:** If `rawDate` is missing (legacy invoice data), fall back to displaying `data.date` as-is. This ensures backward compatibility.
+
+### 2. Browser Language Detection + Cookie Persistence
+
+**File:** `lib/i18n.tsx`
+
+**Changes to `I18nProvider`:**
+
+Add cookie helpers (reuse pattern from `invoice-generator/page.tsx`):
+```typescript
+function getCookie(name: string): string | null {
+  if (typeof document === "undefined") return null;
+  const nameEQ = name + "=";
+  const ca = document.cookie.split(";");
+  for (let i = 0; i < ca.length; i++) {
+    let c = ca[i];
+    while (c.charAt(0) === " ") c = c.substring(1, c.length);
+    if (c.indexOf(nameEQ) === 0) return c.substring(nameEQ.length, c.length);
+  }
+  return null;
+}
+
+function setCookie(name: string, value: string, days = 365) {
+  if (typeof document === "undefined") return;
+  let expires = "";
+  if (days) {
+    const date = new Date();
+    date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000);
+    expires = "; expires=" + date.toUTCString();
+  }
+  document.cookie = name + "=" + (value || "") + expires + "; path=/; SameSite=Lax";
+}
+```
+
+Add browser language detection:
+```typescript
+function detectBrowserLocale(): Locale {
+  if (typeof navigator === "undefined") return "pt";
+  const nav = navigator.language || navigator.languages?.[0] || "";
+  return nav.startsWith("en") ? "en" : "pt";
+}
+```
+
+**Updated locale initialization priority:**
+1. Cookie `locale` (highest priority, persists across sessions and accessible server-side)
+2. localStorage `locale` (existing behavior, kept for backward compatibility)
+3. `navigator.language` detection (new: maps `en-*` to `"en"`, everything else to `"pt"`)
+4. Default `"pt"`
+
+```typescript
+const [locale, setLocaleState] = useState<Locale>(() => {
+  if (typeof window === "undefined") return "pt";
+  const cookieLocale = getCookie("locale") as Locale | null;
+  if (cookieLocale && ["pt", "en"].includes(cookieLocale)) return cookieLocale;
+  const stored = localStorage.getItem("locale") as Locale | null;
+  if (stored && ["pt", "en"].includes(stored)) return stored;
+  return detectBrowserLocale();
+});
+```
+
+**Updated `setLocale`:**
+```typescript
+const setLocale = (l: Locale) => {
+  setLocaleState(l);
+  localStorage.setItem("locale", l);
+  setCookie("locale", l);
+};
+```
+
+### 3. Profile Sync for Logged-in Users
+
+**File:** `app/providers.tsx`
+
+**New component:** `LocaleSync` (sits inside `I18nProvider` and `AuthProvider`)
+
+```typescript
+function LocaleSync({ children }: { children: ReactNode }) {
+  const { user } = useAuth();
+  const { locale, setLocale } = useI18n();
+  const [initialized, setInitialized] = useState(false);
+
+  // On login: fetch profile.locale and apply if it differs
+  useEffect(() => {
+    if (!user) { setInitialized(true); return; }
+    supabase.from("profiles").select("locale").eq("id", user.id).single()
+      .then(({ data }) => {
+        if (data?.locale && ["pt", "en"].includes(data.locale) && data.locale !== locale) {
+          setLocale(data.locale as Locale);
+        }
+        setInitialized(true);
+      });
+  }, [user]);
+
+  // On locale change: update profile if logged in
+  useEffect(() => {
+    if (!user || !initialized) return;
+    supabase.from("profiles").upsert({ id: user.id, locale }, { onConflict: "id" });
+  }, [locale, user, initialized]);
+
+  return <>{children}</>;
+}
+```
+
+**Updated provider tree:**
+```
+QueryClientProvider > I18nProvider > AuthProvider > LocaleSync > FeatureTogglesProvider > EnglishLangGuard > ...
+```
+
+### 4. Additional Hardcoded String Fixes
+
+**`components/InvoicePreview.tsx` line 87:**
+```typescript
+// Before:
+document.title = `Invoice ${data.invoiceNumber || "1"}`;
+// After:
+document.title = `${t("invoice.title")} ${data.invoiceNumber || "1"}`;
+```
+
+**`app/tools/invoice-generator/page.tsx` line 193:**
+```typescript
+// Before:
+toast.success(t("invoice.invoiceNumber") + " #" + newInvoiceNumber + " updated");
+// After:
+toast.success(t("invoice.invoiceNumber") + " #" + newInvoiceNumber + " " + t("invoice.updated"));
+```
+
+**`lib/i18n.tsx` - New translation keys:**
+```typescript
+// PT dictionary:
+"invoice.updated": "atualizado",
+
+// EN dictionary:
+"invoice.updated": "updated",
+```
+
+**`lib/i18n.tsx` - Fix Portuguese date placeholder:**
+```typescript
+// Before (both locales):
+"invoice.datePlaceholder": "May 1, 2026",
+
+// After:
+// PT:
+"invoice.datePlaceholder": "1 de maio de 2026",
+// EN:
+"invoice.datePlaceholder": "May 1, 2026",
+```
+
+---
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `components/InvoicePreview.tsx` | Dynamic date formatting from `rawDate`, internationalize `document.title` |
+| `lib/i18n.tsx` | Cookie helpers, `navigator.language` detection, cookie persistence in `setLocale`, new translation keys, fix PT date placeholder |
+| `app/providers.tsx` | New `LocaleSync` component, update provider tree |
+| `app/tools/invoice-generator/page.tsx` | Use `t("invoice.updated")` instead of hardcoded string |
+
+---
+
+## Backward Compatibility
+
+- **Legacy invoice data:** If `rawDate` is missing, fall back to displaying `data.date` as-is
+- **Existing localStorage users:** Cookie is written on next `setLocale` call; existing localStorage values are still respected during the priority chain
+- **Feature flag guard:** `EnglishLangGuard` continues to force `"pt"` when `is_english_lang_enabled` is off, overriding any detected/delivered locale
+
+---
+
+## Testing
+
+1. **Invoice print:** Create invoice in PT, switch to EN, open print page. Dates should show in English format.
+2. **Browser detection:** Clear localStorage and cookies, set browser to English, load site. Should default to EN.
+3. **Cookie persistence:** Select EN, reload page. Should persist via cookie.
+4. **Profile sync:** Log in, select EN, log out on another device, log in. Should get EN from profile.
+5. **Feature flag:** Disable `is_english_lang_enabled`, verify locale forces to PT regardless of cookie/detection.
+6. **Legacy data:** Open an invoice without `rawDate`, verify dates still display (using `data.date` fallback).

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -183,7 +183,7 @@ const dicts: Record<Locale, Dict> = {
     "invoice.invoiceNumber": "Número da fatura",
     "invoice.currency": "Moeda",
     "invoice.date": "Data",
-    "invoice.datePlaceholder": "May 1, 2026",
+    "invoice.datePlaceholder": "1 de maio de 2026",
     "invoice.paymentTerms": "Condições de pagamento",
     "invoice.paymentTermsPlaceholder": "Condições de pagamento",
     "invoice.dueDate": "Data de vencimento",
@@ -216,6 +216,7 @@ const dicts: Record<Locale, Dict> = {
     "invoice.autoIncrement": "Incrementar número da fatura",
     "invoice.autoDownload": "Baixar automaticamente ao gerar",
     "invoice.generateNext": "Gerar Próxima Fatura",
+    "invoice.updated": "atualizado",
     "privacy.title": "Política de Privacidade",
     "privacy.desc": "Leia nossa Política de Privacidade para entender como coletamos, usamos e protegemos seus dados pessoais de acordo com a LGPD.",
     "privacy.introTitle": "1. Introdução",
@@ -864,6 +865,7 @@ const dicts: Record<Locale, Dict> = {
     "invoice.autoIncrement": "Auto-increment invoice number",
     "invoice.autoDownload": "Auto-download on generation",
     "invoice.generateNext": "Generate Next Invoice",
+    "invoice.updated": "updated",
     "privacy.title": "Privacy Policy",
     "privacy.desc": "Read our Privacy Policy to understand how we collect, use, and protect your personal data in accordance with LGPD.",
     "privacy.introTitle": "1. Introduction",
@@ -1304,6 +1306,35 @@ const dicts: Record<Locale, Dict> = {
   },
 };
 
+function getCookie(name: string): string | null {
+  if (typeof document === "undefined") return null;
+  const nameEQ = name + "=";
+  const ca = document.cookie.split(";");
+  for (let i = 0; i < ca.length; i++) {
+    let c = ca[i];
+    while (c.charAt(0) === " ") c = c.substring(1, c.length);
+    if (c.indexOf(nameEQ) === 0) return c.substring(nameEQ.length, c.length);
+  }
+  return null;
+}
+
+function setCookie(name: string, value: string, days = 365) {
+  if (typeof document === "undefined") return;
+  let expires = "";
+  if (days) {
+    const date = new Date();
+    date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000);
+    expires = "; expires=" + date.toUTCString();
+  }
+  document.cookie = name + "=" + (value || "") + expires + "; path=/; SameSite=Lax";
+}
+
+function detectBrowserLocale(): Locale {
+  if (typeof navigator === "undefined") return "pt";
+  const nav = navigator.language || navigator.languages?.[0] || "";
+  return nav.toLowerCase().startsWith("en") ? "en" : "pt";
+}
+
 interface I18nContextValue {
   locale: Locale;
   setLocale: (l: Locale) => void;
@@ -1312,20 +1343,35 @@ interface I18nContextValue {
 
 const I18nContext = createContext<I18nContextValue | undefined>(undefined);
 
+function readInitialLocale(): Locale {
+  if (typeof window === "undefined") return "pt";
+  const cookieLocale = getCookie("locale") as Locale | null;
+  if (cookieLocale && (cookieLocale === "pt" || cookieLocale === "en")) return cookieLocale;
+  const stored = localStorage.getItem("locale") as Locale | null;
+  if (stored && (stored === "pt" || stored === "en")) return stored;
+  return detectBrowserLocale();
+}
+
 export function I18nProvider({ children }: { children: ReactNode }) {
-  const [locale, setLocaleState] = useState<Locale>(() => {
-    const stored = typeof window !== "undefined" ? (localStorage.getItem("locale") as Locale | null) : null;
-    return stored ?? "pt";
-  });
+  const [locale, setLocaleState] = useState<Locale>(readInitialLocale);
+
+  const setLocale = (l: Locale) => {
+    setLocaleState(l);
+    if (typeof window === "undefined") return;
+    localStorage.setItem("locale", l);
+    setCookie("locale", l);
+  };
 
   useEffect(() => {
+    if (typeof window === "undefined") return;
     localStorage.setItem("locale", locale);
+    setCookie("locale", locale);
     document.documentElement.lang = locale === "pt" ? "pt-BR" : "en";
   }, [locale]);
 
   const t = (key: string) => dicts[locale][key] ?? key;
   return (
-    <I18nContext.Provider value={{ locale, setLocale: setLocaleState, t }}>
+    <I18nContext.Provider value={{ locale, setLocale, t }}>
       {children}
     </I18nContext.Provider>
   );


### PR DESCRIPTION
## Summary

Fixes the invoice generator print process not respecting the browser/i18n language selection, and adds browser-based default language detection with cookie and profile persistence.

## Changes

**Invoice print i18n (components/InvoicePreview.tsx)**
- Dates are now formatted at display time from `rawDate`/`rawDueDate` using the current locale, so an English user printing an invoice created in Portuguese sees "August 23, 2026" instead of "23 de agosto de 2026"
- Internationalized the print document title (uses the translated `invoice.title` key)
- Fallback to the stored `date`/`dueDate` strings for legacy data without `rawDate`

**Toast string (app/tools/invoice-generator/page.tsx)**
- Replaced hardcoded "updated" English text with a new `invoice.updated` i18n key

**Localization keys (lib/i18n.tsx)**
- Added `invoice.updated` (pt: "atualizado", en: "updated")
- Fixed the Portuguese `invoice.datePlaceholder` to "1 de maio de 2026" instead of the English "May 1, 2026"

**Language detection & persistence (lib/i18n.tsx)**
- Added `navigator.language` detection as fallback when no stored preference exists, so first-time English visitors default to English
- Locale persistence now writes a `locale` cookie in addition to `localStorage`
- Priority: cookie > localStorage > browser language > default "pt"

**Profile sync (app/providers.tsx)**
- New `LocaleSync` component applies a signed-in user's saved `profiles.locale` on login and writes locale changes back to the profile for cross-device persistence

## Testing

- `npm run typecheck` passes
- Lint on modified files passes (pre-existing errors in untouched files remain)
