### PR TITLE
feat: mark Onstrider jobs as hot when priority is High

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -2227,7 +2227,7 @@ function JobEditDialog({ job, onClose, onSaved }: { job: any; onClose: () => voi
 
           {job.external_id ? (
             <p className="text-xs text-muted-foreground pt-1">
-              This listing is synced from {job.source ?? "Onstrider"} (external id {job.external_id}). Manual edits to source fields such as company, role, salary, and apply URL may be overwritten by the next scrape.
+              This listing is synced from {job.source ?? "Onstrider"} (external id {job.external_id}). Manual edits to source fields such as company, role, salary, apply URL, and hot status may be overwritten by the next scrape.
             </p>
           ) : null}
 

--- a/supabase/functions/scrape-onstrider/index.ts
+++ b/supabase/functions/scrape-onstrider/index.ts
@@ -355,6 +355,7 @@ async function syncJobs(
       comp_currency: salary.salaryCurrency,
       apply_url: (item.referralUrl ?? "").trim(),
       stack: parseStack(item.requiredSkillsLabel),
+      is_hot: (item.priority ?? "").trim().toLowerCase() === "high",
     } as const;
 
     const existing = existingByExternal[externalId];
@@ -375,7 +376,6 @@ async function syncJobs(
         posted_at: nowIso,
         published_at: nowIso,
         is_featured: false,
-        is_hot: false,
         is_verified_company: false,
       });
       if (insertError) throw insertError;


### PR DESCRIPTION
## Summary

Maps Onstrider's job 'priority' field to the jobs board's 'is_hot' flag. Jobs marked 'High' priority on Onstrider are now automatically flagged as hot on our board.

## Changes
- supabase/functions/scrape-onstrider/index.ts: reads item.priority from the Onstrider API and sets is_hot=true when priority is High (case-insensitive)
- Removed hardcoded is_hot:false from the job insert (now derived from priority)
- app/admin/page.tsx: updated the scraped-job warning note to mention hot status may be overwritten by the next scrape

## Verification
- Rebased on latest master (PR #16 admin editing already merged)
- Typecheck/main project passes; next build succeeds