### PR TITLE
fix: populate Onstrider job descriptions on scrape

### DIFF
--- a/supabase/functions/scrape-onstrider/index.ts
+++ b/supabase/functions/scrape-onstrider/index.ts
@@ -448,6 +448,11 @@ async function syncJobs(
     if (!externalId) continue;
     seenExternal.add(externalId);
 
+    // The detail endpoint is keyed on the listing's `externalId`, which is a
+    // separate UUID from `item.id`. `item.id` stays the DB `external_id`
+    // (dedup key); `item.externalId` is what the detail fetch requires.
+    const detailId = item?.externalId ?? externalId;
+
     const title = (item.title ?? "").trim();
     if (!title) continue;
 
@@ -488,7 +493,7 @@ async function syncJobs(
 
     let record = base;
     if (needsDetail) {
-      record = await buildDetailRecord(session, externalId, base);
+      record = await buildDetailRecord(session, detailId, base);
       await sleep(200);
     }
 

--- a/supabase/functions/scrape-onstrider/index.ts
+++ b/supabase/functions/scrape-onstrider/index.ts
@@ -398,12 +398,16 @@ async function buildDetailRecord(
 }
 
 function detailMissing(row: { description: string | null; country_codes: string[] | null; location: string | null; company_size: string | null; industry: string | null; role_category: string | null }): boolean {
-  return !row.description &&
-    !(Array.isArray(row.country_codes) && row.country_codes.length > 0) &&
-    !row.location &&
-    !row.company_size &&
-    !row.industry &&
-    !row.role_category;
+  // Re-fetch the job detail whenever the description (the core content field,
+  // and the one users actually see) is missing, or when all the remaining
+  // detail-only enrichment fields are empty. `location` is intentionally
+  // excluded: the base import always defaults it to "Remote", so including it
+  // here would prevent backfilling description on already-imported jobs.
+  return !row.description ||
+    (!(Array.isArray(row.country_codes) && row.country_codes.length > 0) &&
+      !row.company_size &&
+      !row.industry &&
+      !row.role_category);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Users on the single-job detail page (`app/jobs/[slug]/page.tsx`) see salary and stack but **no description**, and `jobs.description` stays NULL even after re-running the scraper.

Two root causes, both fixed here:

### 1. Wrong UUID for the detail endpoint (the 404)

The Onstrider detail endpoint `GET /api/referrals/job-listings/{id}` is keyed on the listing's `externalId` (e.g. `b97a7621-...`), a separate UUID from `item.id`. The scraper was calling it with `item.id`, which the endpoint rejects:

```
job detail fetch failed (404) for 54568533-43b2-4010-86ab-860d1c8a84aa: {"message":"Resource not found."}
```

Fix: keep `item.id` as the DB `external_id` (the dedup key, per the design doc), but fetch detail using `item.externalId`:

```ts
const detailId = item?.externalId ?? externalId;
...
record = await buildDetailRecord(session, detailId, base);
```

### 2. Backfill never triggered for existing jobs

`detailMissing()` required all enrichment fields to be empty, but `location` is always defaulted to `"Remote"` by the base import, so it never returned true for already-imported jobs and the detail fetch (which populates `description`) was skipped.

Fix: fetch detail whenever `description` is missing, or the remaining detail-only fields are all empty, excluding the always-set `location`:

```ts
return !row.description ||
  (!(Array.isArray(row.country_codes) && row.country_codes.length > 0) &&
    !row.company_size && !row.industry && !row.role_category);
```

## verification

- `deno check` on `scrape-onstrider/index.ts`: pass

## note

Requires redeploying the `scrape-onstrider` edge function, then re-running it, for the fixes to take effect.
