### PR TITLE
feat: cache /analytics data for one hour

### DIFF
--- a/supabase/functions/public-analytics/index.ts
+++ b/supabase/functions/public-analytics/index.ts
@@ -12,8 +12,21 @@ import { enforceRateLimit } from "../_shared/rate_limit.ts";
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
-  "Cache-Control": "public, max-age=300, stale-while-revalidate=600",
+  // The aggregation is expensive and refreshes hourly, so also cache at the
+  // CDN/browser layer for the same 1-hour window that the in-memory cache uses.
+  "Cache-Control": "public, max-age=3600, stale-while-revalidate=3600",
 };
+
+// Refresh analytics at most once an hour. Aggregating the whole platform (every
+// profile, job, analysis, etc.) is expensive, so the computed result is memoized
+// in-memory and served to all callers for the TTL window. Keep it aligned with
+// the Cache-Control header above.
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+let cachedResult: {
+  computedAt: number;
+  payload: unknown;
+} | null = null;
 
 // Bucket ISO date strings (YYYY-MM-DD) into a cumulative map keyed by date.
 // `rows` must be an array of objects carrying a `created_at` column.
@@ -52,6 +65,89 @@ function buildDailySeries(rows: Array<{ created_at: string | null }>): Array<{
   return sorted.map((day) => ({ date: day, added: byDay.get(day) ?? 0 }));
 }
 
+async function computeAnalytics(): Promise<{ generated_at: string; [key: string]: unknown }> {
+  const client = createClient(
+    Deno.env.get("SUPABASE_URL") ?? "",
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",
+  );
+
+  const memberRows = await client.from("profiles").select("created_at, onboarded_at, subscription_status, xp_points");
+  const jobRows = await client.from("jobs").select("created_at").eq("status", "published").eq("is_active", true);
+  const analysisRows = await client.from("resume_analyses").select("created_at");
+  const applicationRows = await client.from("applications").select("created_at");
+  const projectRows = await client.from("side_projects").select("created_at").eq("status", "approved");
+  const recruiterRows = await client.from("recruiter_profiles").select("created_at");
+  const searchRows = await client.from("candidate_searches").select("created_at");
+  const interestRows = await client.from("candidate_interests").select("created_at");
+  const achievementEarnRows = await client.from("user_achievements").select("earned_at");
+  const classRows = await client.from("class_progress").select("completed");
+  const companyRows = await client.from("companies").select("id");
+
+  if (
+    memberRows.error || jobRows.error || analysisRows.error || applicationRows.error
+    || projectRows.error || recruiterRows.error || searchRows.error || interestRows.error
+    || achievementEarnRows.error || classRows.error || companyRows.error
+  ) {
+    throw new Error("Failed to aggregate analytics");
+  }
+
+  const memberRowsArr = memberRows.data ?? [];
+  const jobRowsArr = (jobRows.data ?? []).map((r) => ({ created_at: r.created_at }));
+  const analysisRowsArr = (analysisRows.data ?? []).map((r) => ({ created_at: r.created_at }));
+  const applicationRowsArr = (applicationRows.data ?? []).map((r) => ({ created_at: r.created_at }));
+  const projectRowsArr = (projectRows.data ?? []).map((r) => ({ created_at: r.created_at }));
+  const recruiterRowsArr = (recruiterRows.data ?? []).map((r) => ({ created_at: r.created_at }));
+  const searchRowsArr = (searchRows.data ?? []).map((r) => ({ created_at: r.created_at }));
+  const interestRowsArr = (interestRows.data ?? []).map((r) => ({ created_at: r.created_at }));
+
+  const memberCreated = memberRowsArr.map((r) => ({ created_at: r.created_at }));
+  const onboarded = memberRowsArr.filter((r) => r.onboarded_at).length;
+  const proMembers = memberRowsArr.filter(
+    (r) => r.subscription_status === "pro",
+  ).length;
+  const totalXp = memberRowsArr.reduce((acc, r) => acc + (r.xp_points ?? 0), 0);
+
+  const achievementEarned = (achievementEarnRows.data ?? [])
+    .map((r) => ({ created_at: r.earned_at }))
+    .filter((r) => r.created_at);
+  const completedLessons = (classRows.data ?? []).filter((r) => r.completed).length;
+
+  return {
+    generated_at: new Date().toISOString(),
+    catalogue: {
+      jobs: jobRowsArr.length,
+      companies: companyRows.data?.length ?? 0,
+      side_projects: projectRowsArr.length,
+    },
+    members: {
+      total: memberRowsArr.length,
+      onboarded,
+      pro_subscribers: proMembers,
+      total_xp: totalXp,
+      cumulative: buildCumulativeSeries(memberCreated),
+    },
+    growth: {
+      jobs_daily: buildDailySeries(jobRowsArr),
+      analyses_daily: buildDailySeries(analysisRowsArr),
+      members_daily: buildDailySeries(memberCreated),
+    },
+    funnel: {
+      resume_analyses: analysisRowsArr.length,
+      applications: applicationRowsArr.length,
+    },
+    recruiter: {
+      companies: recruiterRowsArr.length,
+      searches: searchRowsArr.length,
+      interests: interestRowsArr.length,
+    },
+    engagement: {
+      achievements_earned: achievementEarned.length,
+      completed_lessons: completedLessons,
+      achievements_series: buildCumulativeSeries(achievementEarned),
+    },
+  };
+}
+
 Deno.serve(async (req) => {
   if (req.method === "OPTIONS") {
     return new Response("ok", { headers: corsHeaders });
@@ -66,93 +162,38 @@ Deno.serve(async (req) => {
       });
     }
 
-    const client = createClient(
-      Deno.env.get("SUPABASE_URL") ?? "",
-      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",
-    );
+    // Serve the cached result when it is still fresh, avoiding the expensive
+    // multi-table aggregation for every request during the hour.
+    const cachedAt = cachedResult?.computedAt ?? 0;
+    const isFresh = cachedResult && Date.now() - cachedAt < CACHE_TTL_MS;
 
-    const memberRows = await client.from("profiles").select("created_at, onboarded_at, subscription_status, xp_points");
-    const jobRows = await client.from("jobs").select("created_at").eq("status", "published").eq("is_active", true);
-    const analysisRows = await client.from("resume_analyses").select("created_at");
-    const applicationRows = await client.from("applications").select("created_at");
-    const projectRows = await client.from("side_projects").select("created_at").eq("status", "approved");
-    const recruiterRows = await client.from("recruiter_profiles").select("created_at");
-    const searchRows = await client.from("candidate_searches").select("created_at");
-    const interestRows = await client.from("candidate_interests").select("created_at");
-    const achievementEarnRows = await client.from("user_achievements").select("earned_at");
-    const classRows = await client.from("class_progress").select("completed");
-    const companyRows = await client.from("companies").select("id");
+    let payload: unknown;
+    let servedFromCache = false;
 
-    if (
-      memberRows.error || jobRows.error || analysisRows.error || applicationRows.error
-      || projectRows.error || recruiterRows.error || searchRows.error || interestRows.error
-      || achievementEarnRows.error || classRows.error || companyRows.error
-    ) {
-      return new Response(JSON.stringify({ error: "Failed to aggregate analytics" }), {
-        status: 500,
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      });
+    if (isFresh) {
+      payload = cachedResult!.payload;
+      servedFromCache = true;
+    } else {
+      payload = await computeAnalytics();
+      cachedResult = { computedAt: Date.now(), payload };
     }
 
-    const memberRowsArr = memberRows.data ?? [];
-    const jobRowsArr = (jobRows.data ?? []).map((r) => ({ created_at: r.created_at }));
-    const analysisRowsArr = (analysisRows.data ?? []).map((r) => ({ created_at: r.created_at }));
-    const applicationRowsArr = (applicationRows.data ?? []).map((r) => ({ created_at: r.created_at }));
-    const projectRowsArr = (projectRows.data ?? []).map((r) => ({ created_at: r.created_at }));
-    const recruiterRowsArr = (recruiterRows.data ?? []).map((r) => ({ created_at: r.created_at }));
-    const searchRowsArr = (searchRows.data ?? []).map((r) => ({ created_at: r.created_at }));
-    const interestRowsArr = (interestRows.data ?? []).map((r) => ({ created_at: r.created_at }));
+    const refreshAfter = servedFromCache
+      ? new Date(cachedAt + CACHE_TTL_MS).toUTCString()
+      : new Date(Date.now() + CACHE_TTL_MS).toUTCString();
 
-    const memberCreated = memberRowsArr.map((r) => ({ created_at: r.created_at }));
-    const onboarded = memberRowsArr.filter((r) => r.onboarded_at).length;
-    const proMembers = memberRowsArr.filter(
-      (r) => r.subscription_status === "pro",
-    ).length;
-    const totalXp = memberRowsArr.reduce((acc, r) => acc + (r.xp_points ?? 0), 0);
-
-    const achievementEarned = (achievementEarnRows.data ?? [])
-      .map((r) => ({ created_at: r.earned_at }))
-      .filter((r) => r.created_at);
-    const completedLessons = (classRows.data ?? []).filter((r) => r.completed).length;
-
-    const result = {
-      generated_at: new Date().toISOString(),
-      catalogue: {
-        jobs: jobRowsArr.length,
-        companies: companyRows.data?.length ?? 0,
-        side_projects: projectRowsArr.length,
-      },
-      members: {
-        total: memberRowsArr.length,
-        onboarded,
-        pro_subscribers: proMembers,
-        total_xp: totalXp,
-        cumulative: buildCumulativeSeries(memberCreated),
-      },
-      growth: {
-        jobs_daily: buildDailySeries(jobRowsArr),
-        analyses_daily: buildDailySeries(analysisRowsArr),
-        members_daily: buildDailySeries(memberCreated),
-      },
-      funnel: {
-        resume_analyses: analysisRowsArr.length,
-        applications: applicationRowsArr.length,
-      },
-      recruiter: {
-        companies: recruiterRowsArr.length,
-        searches: searchRowsArr.length,
-        interests: interestRowsArr.length,
-      },
-      engagement: {
-        achievements_earned: achievementEarned.length,
-        completed_lessons: completedLessons,
-        achievements_series: buildCumulativeSeries(achievementEarned),
-      },
+    const headers = {
+      ...corsHeaders,
+      "Content-Type": "application/json",
+      // CDN/browser caching is handled by Cache-Control above; expose the cache
+      // provenance for debugging.
+      "X-Analytics-Cache": servedFromCache ? "HIT" : "MISS",
+      "Refresh-After": refreshAfter,
     };
 
-    return new Response(JSON.stringify(result), {
+    return new Response(JSON.stringify(payload), {
       status: 200,
-      headers: { ...corsHeaders, "Content-Type": "application/json" },
+      headers,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";


### PR DESCRIPTION
## What

Adds a caching layer to the `/analytics` page data so it refreshes at most once an hour instead of aggregating the whole platform on every request.

## Where

Server-side in the `public-analytics` Supabase Edge Function (the right place, since every page load currently triggers ~11 table-wide aggregation queries per visitor).

## How it works

- The computed analytics payload is memoized **in-memory** with a **1-hour TTL** (`CACHE_TTL_MS`).
- On a **cache hit** the endpoint returns the stored JSON immediately, with **no DB queries**.
- On a **cache miss** (first request or after TTL expiry) it runs the aggregation once (`computeAnalytics()`) and stores the result.
- `generated_at` reflects when the data was actually aggregated, so served-from-cache responses still show the true snapshot time.
- Response `Cache-Control` is now `public, max-age=3600, stale-while-revalidate=3600` so the CDN/browser cache matches the 1-hour in-memory window.
- Added `X-Analytics-Cache: HIT|MISS` and `Refresh-After` headers for observability.

## Verification

- `deno check` on `supabase/functions/public-analytics/index.ts`: pass
- Reverted the unrelated automated `deno.lock` bump.

## Note

Requires **redeploying** the `public-analytics` edge function for the cache to take effect.
