### PR TITLE
feat: localize AI resume analysis to user language and fix detected stack badge contrast

### DIFF
--- a/app/analyze/page.tsx
+++ b/app/analyze/page.tsx
@@ -92,7 +92,7 @@ function CategoryScoresGrid({
 
 export default function AnalyzeResume() {
   const { user } = useAuth();
-  const { t } = useI18n();
+  const { t, locale } = useI18n();
   const fileRef = useRef<HTMLInputElement>(null);
   const [targetRole, setTargetRole] = useState("");
   const [pasted, setPasted] = useState("");
@@ -146,6 +146,7 @@ export default function AnalyzeResume() {
         action: "analyze",
         user_id: user?.id ?? null,
         target_role: targetRole.trim() || null,
+        locale,
       };
       if (file) {
         if (file.size > 10 * 1024 * 1024) throw new Error("Max 10MB");
@@ -200,7 +201,7 @@ export default function AnalyzeResume() {
     setUnlocking(true);
     try {
       const { data, error } = await supabase.functions.invoke("analyze-resume", {
-        body: { action: "unlock", id, email },
+        body: { action: "unlock", id, email, locale },
       });
       if (error) throw error;
       if (data?.error) throw new Error(data.error);
@@ -465,7 +466,7 @@ export default function AnalyzeResume() {
                     <div className="text-xs uppercase tracking-widest text-muted-foreground">{t("analyze.detectedStack")}</div>
                     <div className="mt-2 flex flex-wrap gap-2">
                       {partial.detected_stack.map((r, i) => (
-                        <span key={i} className="text-xs rounded-full bg-secondary px-2.5 py-1">{r}</span>
+                        <span key={i} className="text-xs rounded-full bg-secondary text-secondary-foreground px-2.5 py-1">{r}</span>
                       ))}
                     </div>
                   </div>

--- a/supabase/functions/analyze-resume/index.ts
+++ b/supabase/functions/analyze-resume/index.ts
@@ -94,6 +94,7 @@ Deno.serve(async (req) => {
       if (!rl.allowed) return json({ error: rl.error }, rl.status);
 
       const { file_base64, file_name, resume_text, user_id, target_role } = body;
+      const locale = body.locale === "en" ? "en" : "pt";
 
       const authedUserId = await getAuthenticatedUserId(req);
       if (user_id && authedUserId && user_id !== authedUserId) return json({ error: "Forbidden" }, 403);
@@ -129,7 +130,7 @@ RULES:
 - category_scores: array of exactly 6 objects. Each must have "id" (one of "ats","keywords","formatting","impact","english","role_fit"), "score" (integer 0-100), and "tip" (string, max 90 chars)
 - quick_win: one sentence, the highest-impact fix
 ${roleHint ? `Weight role_fit against the target role: "${roleHint}".` : "If no target role is given, score role_fit based on general US remote tech market fit."}
-Be candid but constructive.`;
+Be candid but constructive. All user-facing text fields (top_strengths, top_gaps, suggested_roles, detected_stack, quick_win, and every tip in category_scores) must be written in ${locale === "pt" ? "Brazilian Portuguese (pt-BR)" : "English (en)"}.`;
       const ai = await callAI(analyzePrompt, userPayload, { models: FREE_MODELS, json: true });
       if (!ai.ok) return json({ error: ai.error }, ai.status);
 
@@ -145,6 +146,7 @@ Be candid but constructive.`;
       }
 
       if (roleHint) partial.target_role = roleHint;
+      partial.locale = locale;
 
       const { data: row, error } = await supabase.from("resume_analyses").insert({
         user_id: authedUserId,
@@ -169,6 +171,10 @@ Be candid but constructive.`;
       const { data: row, error } = await supabase.from("resume_analyses").select("*").eq("id", id).maybeSingle();
       if (error || !row) throw new Error("Análise não encontrada");
 
+      const locale = body.locale === "en" || body.locale === "pt"
+        ? body.locale
+        : ((row.partial as { locale?: string })?.locale === "en" ? "en" : "pt");
+
       let full = row.full_report;
       if (!full) {
         const partialRole = (row.partial as { target_role?: string })?.target_role ?? "";
@@ -192,7 +198,8 @@ RULES:
 - risk_flags: array of short strings (red flags for ATS or recruiters)
 - formatting_issues: array of up to 5 strings (layout/structure problems)
 - role_fit_summary: 2 sentences on fit for target role, or general US remote fit if none
-- category_scores: array of exactly 6 objects. Each must have "id" (one of "ats","keywords","formatting","impact","english","role_fit"), "score" (integer 0-100), and "tip" (string, max 90 chars)`;
+- category_scores: array of exactly 6 objects. Each must have "id" (one of "ats","keywords","formatting","impact","english","role_fit"), "score" (integer 0-100), and "tip" (string, max 90 chars)
+All user-facing text fields (readiness_summary, bullet_rewrites, missing_keywords, english_recommendations, 30_day_plan, risk_flags, formatting_issues, role_fit_summary, and every tip in category_scores) must be written in ${locale === "pt" ? "Brazilian Portuguese (pt-BR)" : "English (en)"}.`;
         const ai = await callAI(unlockPrompt, fullPayload, { models: FREE_MODELS, json: true });
         if (!ai.ok) return json({ error: ai.error }, ai.status);
         full = robustJsonParse(ai.text);


### PR DESCRIPTION
## What

Localizes the AI resume analysis to the user's current language (pt-BR or en) and fixes a UI contrast bug in the detected stack badges.

## Language localization

The analyze-resume AI now writes all user-facing text fields (strengths, gaps, suggested roles, detected stack, quick win, tips, and all unlock report fields) in the user's active language instead of always defaulting to one.

- `app/analyze/page.tsx` reads `locale` from `useI18n()` and passes it in both the `analyze` and `unlock` function requests.
- `supabase/functions/analyze-resume/index.ts` reads `locale` from the request body and appends a language instruction to both the analyze and unlock prompts. The locale is also stored in the `partial` record so a later unlock reuses the language chosen at analysis time even if the frontend doesn't resend it.

## Detected stack badge fix

The "Stack detectada" / "Detected stack" badges rendered with both text and background near-black. Added `text-secondary-foreground` to the badge span so the text is readable against `bg-secondary`.
