### PR TITLE
fix: robust JSON parsing for cover letter AI response

### DIFF
--- a/app/tools/cover-letter/page.tsx
+++ b/app/tools/cover-letter/page.tsx
@@ -360,6 +360,28 @@ function CoverLetterGeneratorInner() {
     [t],
   );
 
+  // Normalize a backend letter value into a plain string. Guards against the
+  // server ever returning a raw JSON object/string blob instead of a paragraph.
+  const normalizeLetter = (value: unknown): string => {
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed.startsWith("{")) {
+        try {
+          const parsed = JSON.parse(trimmed);
+          if (parsed && typeof parsed.letter === "string") return parsed.letter;
+        } catch {
+          /* not JSON, use as-is */
+        }
+      }
+      return trimmed;
+    }
+    if (value && typeof value === "object") {
+      const maybe = (value as Record<string, unknown>).letter;
+      if (typeof maybe === "string") return maybe;
+    }
+    return "";
+  };
+
   const generate = async () => {
     setLoading(true);
     setMeta(null);
@@ -383,7 +405,7 @@ function CoverLetterGeneratorInner() {
       if (error) throw error;
       if (data?.error) throw new Error(data.error);
       const result = data as GenerateResult;
-      setLetter(result.letter ?? "");
+      setLetter(normalizeLetter(result.letter));
       setRecordId(result.id);
       setMeta({
         id: result.id,
@@ -598,7 +620,7 @@ function CoverLetterGeneratorInner() {
     setTone(item.tone || "confident");
     setLanguage(item.language || "en");
     setTemplateId(item.template_id || "classic");
-    setLetter(item.generated_text || "");
+    setLetter(normalizeLetter(item.generated_text || ""));
     setRecordId(item.id);
     setMeta({
       id: item.id,

--- a/supabase/functions/cover-letter/index.ts
+++ b/supabase/functions/cover-letter/index.ts
@@ -63,17 +63,33 @@ function json(data: unknown, status: number) {
   });
 }
 
+// Extract the first JSON object from a model response, tolerating markdown
+// fences, leading prose, and trailing text that some free models emit even
+// when json_object mode is requested. Returns null when no valid object found.
+function extractJson<T>(raw: string): T | null {
+  const text = String(raw ?? "").trim();
+  if (!text) return null;
+  const start = text.indexOf("{");
+  const end = text.lastIndexOf("}");
+  if (start === -1 || end === -1 || end <= start) return null;
+  const candidate = text.slice(start, end + 1);
+  try {
+    return JSON.parse(candidate) as T;
+  } catch {
+    return null;
+  }
+}
+
 async function runAI(system: string, user: string) {
   const ai = await callOpenAIRoute(system, user, { models: FREE_MODELS, json: true });
   if (!ai.ok) {
     return { error: ai.error, status: ai.status };
   }
-  const raw = ai.text ?? "{}";
-  try {
-    return { data: JSON.parse(raw) };
-  } catch {
-    return { data: { letter: raw, matched_keywords: [], missing_keywords: [], keyword_coverage: 0 } };
+  const parsed = extractJson<Record<string, unknown>>(ai.text ?? "");
+  if (!parsed) {
+    return { error: "The AI returned an unreadable response, please try again.", status: 502 };
   }
+  return { data: parsed };
 }
 
 Deno.serve(async (req) => {


### PR DESCRIPTION
Fixes the cover letter generator breaking when the free-tier AI model returns markdown fences or prose around the JSON, or the letter value comes back as a raw JSON object instead of a string.

Changes:
- add \extractJson\ helper in the edge function to pull the first valid JSON object from the model response
- return a clear 502 error instead of silently emitting garbage when the response cannot be parsed
- normalize the letter value on the client so a nested/stringified JSON letter still renders as plain text