### PR TITLE
fix: crash on /recruiter/search when a candidate has no stack

### DIFF
--- a/components/CandidateCard.tsx
+++ b/components/CandidateCard.tsx
@@ -36,6 +36,8 @@ export function CandidateCard({ candidate, onExpressInterest }: CandidateCardPro
     is_blurred
   } = candidate;
 
+  const techStack = stack ?? [];
+
   return (
     <div className="rounded-xl border bg-card p-5 transition-all hover:border-primary/40 group">
       <div className="flex gap-4 items-start">
@@ -69,7 +71,7 @@ export function CandidateCard({ candidate, onExpressInterest }: CandidateCardPro
 
       <div className="mt-4">
         <div className="flex flex-wrap gap-1.5 h-14 overflow-hidden">
-          {stack.map((tech, idx) => (
+          {techStack.map((tech, idx) => (
             <span key={idx} className="text-xs bg-secondary text-secondary-foreground px-2 py-0.5 rounded-md">
               {tech}
             </span>


### PR DESCRIPTION
Fixes the runtime error on /recruiter/search:\n\n\TypeError: Cannot read properties of null (reading 'map')\ in \CandidateCard\.\n\n**Root cause**\n\profiles.stack\ is nullable (\string[] | null\). The \ecruiter-search\ edge function returns \stack\ as-is, so a candidate with no stack set arrives as \
ull\. In \CandidateCard\, the destructuring default \stack = []\ only kicks in for \undefined\, not \
ull\, so \stack\ stays \
ull\ and \stack.map(...)\ throws.\n\n**Fix**\nFall back to an empty array before mapping (\stack ?? []\), so the tags row renders nothing for candidates without a stack.\n\nVerified: tsc and production build pass.