### PR TITLE
fix: repair invoice-generator link and add 301 redirect

### DIFF
--- a/app/tools/page.tsx
+++ b/app/tools/page.tsx
@@ -15,7 +15,7 @@ export default function Tools() {
     { to: "/tools/resume", icon: FileText, title: t("resume.title"), desc: t("tools.resumeDesc"), pro: true },
     { to: "/tools/linkedin", icon: User, title: t("linkedin.title"), desc: t("tools.linkedinDesc"), pro: true },
     { to: "/tools/salary", icon: Calculator, title: t("salary.title"), desc: t("tools.salaryDesc"), pro: false },
-    { to: "/invoice-generator", icon: ReceiptText, title: t("invoice.toolTitle"), desc: t("invoice.toolSubtitle"), pro: false },
+    { to: "/tools/invoice-generator", icon: ReceiptText, title: t("invoice.toolTitle"), desc: t("invoice.toolSubtitle"), pro: false },
     { to: "/english", icon: Scale, title: t("english.title"), desc: t("english.subtitle"), pro: true },
   ];
   return (

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,15 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async redirects() {
+    return [
+      {
+        source: "/invoice-generator",
+        destination: "/tools/invoice-generator",
+        statusCode: 301,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Fixes a broken link and adds a permanent redirect for legacy URLs.

**Broken link**
- `app/tools/page.tsx`: the tools directory card pointed to `/invoice-generator` (a path that does not exist) and now points to the real page at `/tools/invoice-generator`.

**301 redirect**
- `next.config.ts`: added a `redirects` entry mapping `/invoice-generator` to `/tools/invoice-generator` with `statusCode: 301`. This preserves the request method and gives search engines the exact 301 (the `permanent: true` option would emit a 308, so `statusCode` is used to match the intended 301).